### PR TITLE
Extract Spotify redirect_uri for portability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-## [2.0.1] - 2020.xx.xx
-### XXXXXXXXXX
+## [2.0.2] - 2020.xx.xx
+### Changed
+- 
 
+
+## [2.0.1] - 2020.09.25
+### Changed
+- Extract REDIRECT_URI to ENV variable
 
 ## [2.0.0] - 2020.09.25
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@ Spotify uses OAuth2 for authentication and authorization. On initial setup [App 
 All updates are tracked in the [Changelog](https://github.com/ianhuet/react-spotify/blob/master/CHANGELOG.md) under [Semantic Versioning](https://semver.org/).
 
 
-### Bundler
-Webpack (v.3.8) is used to produce either development or production builds.
-
-
 ### Source Project Specs
+Built on Create-React-App and ejected. Webpack (v.3.8) is the bundler.
 
 *Dependancies*
 - React 16.1.1

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ class App extends Component {
 
   componentDidMount() {
     const clientId = '47e2c485aa3c47a6a39e71bb2fcf4da4';
-    const redirectUri = 'http://localhost:3000/app';
+    const redirectUri = process.env.REACT_APP_REDIRECT_URI;
     const scopes = ['playlist-read-private', 'playlist-read-collaborative', 'playlist-modify-public', 'user-read-recently-played', 'playlist-modify-private', 'ugc-image-upload', 'user-follow-modify', 'user-follow-read', 'user-library-read', 'user-library-modify', 'user-read-private', 'user-read-email', 'user-top-read', 'user-read-playback-state'];
     const authorisationUrl = 
       `https://accounts.spotify.com/authorize?client_id=${clientId}&scope=${scopes.join('%20')}&response_type=token&redirect_uri=${redirectUri}`;


### PR DESCRIPTION
Enable deployment portability by extracting the Spotify Redirect URI to ENV variable REACT_APP_REDIRECT_URI